### PR TITLE
fix(react-scripts): remove source-maps after build

### DIFF
--- a/packages/react-scripts/scripts/build.js
+++ b/packages/react-scripts/scripts/build.js
@@ -33,6 +33,7 @@ const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 const printHostingInstructions = require('react-dev-utils/printHostingInstructions');
 const FileSizeReporter = require('react-dev-utils/FileSizeReporter');
 const printBuildError = require('react-dev-utils/printBuildError');
+const rimraf = require('rimraf');
 
 const measureFileSizesBeforeBuild =
   FileSizeReporter.measureFileSizesBeforeBuild;
@@ -60,6 +61,7 @@ measureFileSizesBeforeBuild(paths.appBuild)
     // Start the webpack build
     return build(previousFileSizes);
   })
+  .then(buildResultData => removeSourceMaps(buildResultData))
   .then(
     ({ stats, previousFileSizes, warnings }) => {
       if (warnings.length) {
@@ -147,6 +149,12 @@ function build(previousFileSizes) {
         warnings: messages.warnings,
       });
     });
+  });
+}
+
+function removeSourceMaps(buildResultData) {
+  return new Promise(resolve => {
+    rimraf(`${paths.appBuild}/**/*.map`, () => resolve(buildResultData));
   });
 }
 


### PR DESCRIPTION
#### :tophat: What? Why?

We where generating and uploading the source-maps but we where not deleting them after the build

#### :ghost: GIF
![](https://media2.giphy.com/media/3o7aDcYHcBee34V6uc/giphy.gif)