### PR TITLE
DO components procesing

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -46,6 +46,8 @@ function getServedPath(appPackageJson) {
   return ensureSlash(servedUrl, true);
 }
 
+var doComponentModulesRegex = /node_modules[\\/]@digital-origin[\\/]do-component-/;
+
 // config after eject: we're in ./config/
 module.exports = {
   dotenv: resolveApp('.env'),
@@ -60,6 +62,7 @@ module.exports = {
   appNodeModules: resolveApp('node_modules'),
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
+  doComponentModulesRegex: doComponentModulesRegex,
 };
 
 // @remove-on-eject-begin
@@ -83,6 +86,7 @@ module.exports = {
   // These properties only exist before ejecting:
   ownPath: resolveOwn('.'),
   ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3
+  doComponentModulesRegex: doComponentModulesRegex,
 };
 
 const ownPackageJson = require('../package.json');
@@ -113,6 +117,7 @@ if (
     // These properties only exist before ejecting:
     ownPath: resolveOwn('.'),
     ownNodeModules: resolveOwn('node_modules'),
+    doComponentModulesRegex: doComponentModulesRegex,
   };
 }
 // @remove-on-eject-end

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -167,7 +167,7 @@ module.exports = {
           // Process JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,
-            include: paths.appSrc,
+            include: [paths.appSrc, paths.doComponentModulesRegex],
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -208,7 +208,7 @@ module.exports = {
           // Process JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,
-            include: paths.appSrc,
+            include: [paths.appSrc, paths.doComponentModulesRegex],
             loader: require.resolve('babel-loader'),
             options: {
               // @remove-on-eject-begin


### PR DESCRIPTION
#### :tophat: What? Why?

In order to get do-components working with internal css loading, we have to process do-components modules directly from node_modules


#### :ghost: GIF
![](https://media.giphy.com/media/l0HUoKHxFD8lx56pi/giphy.gif)
