### PR TITLE
Add sass-resource-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Extra environments added:
 | GTM_ID | Google Tag Manager container Id |
 | GTM_AUTH | Google Tag Manager authorization token (useful form multiple environments in GTM) |
 | GTM_PREVIEW | Google Tag Manager env preview (useful form multiple environments in GTM) |
+| PATHS_TO_SASS_RESOURCES_TO_INJECT | Path/s from app directory where to find sass resources to inject in every sass file (```./src/my/resource._scss ./src/my/other/resource.scss ```) |
 
 Now up next the original Create React App readme
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Extra environments added:
 | GTM_ID | Google Tag Manager container Id |
 | GTM_AUTH | Google Tag Manager authorization token (useful form multiple environments in GTM) |
 | GTM_PREVIEW | Google Tag Manager env preview (useful form multiple environments in GTM) |
-| PATHS_TO_SASS_RESOURCES_TO_INJECT | Path/s file/s (as specified in [here](https://github.com/shakacode/sass-resources-loader#glob-pattern-matching)) from app directory where to find sass resources to inject in every sass file |
+| SASS_RESOURCES_TO_INJECT | Path/s File/s from app directory where to find sass resources to inject in every sass file (```./src/my/resource._scss ./src/my/other/resource.scss ```) |
 
 Now up next the original Create React App readme
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Extra environments added:
 | GTM_ID | Google Tag Manager container Id |
 | GTM_AUTH | Google Tag Manager authorization token (useful form multiple environments in GTM) |
 | GTM_PREVIEW | Google Tag Manager env preview (useful form multiple environments in GTM) |
-| PATHS_TO_SASS_RESOURCES_TO_INJECT | Path/s from app directory where to find sass resources to inject in every sass file (```./src/my/resource._scss ./src/my/other/resource.scss ```) |
+| PATHS_TO_SASS_RESOURCES_TO_INJECT | Path/s file/s (as specified in [here](https://github.com/shakacode/sass-resources-loader#glob-pattern-matching)) from app directory where to find sass resources to inject in every sass file |
 
 Now up next the original Create React App readme
 

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -30,6 +30,18 @@ const publicUrl = '';
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
 
+let extraSassLoaders = [];
+if (process.env.PATHS_TO_SASS_RESOURCES_TO_INJECT) {
+  extraSassLoaders.push({
+    loader: require.resolve('sass-resources-loader'),
+    options: {
+      resources: process.env.PATHS_TO_SASS_RESOURCES_TO_INJECT
+        .split(' ')
+        .map(sassPath => path.resolve(paths.appPath, sassPath)),
+    },
+  });
+}
+
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
@@ -258,6 +270,7 @@ module.exports = {
                   includePaths: [].concat(paths.appSrc),
                 },
               },
+              ...extraSassLoaders,
             ],
           },
           // "file" loader makes sure those assets get served by WebpackDevServer.

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -31,11 +31,11 @@ const publicUrl = '';
 const env = getClientEnvironment(publicUrl);
 
 let extraSassLoaders = [];
-if (process.env.PATHS_TO_SASS_RESOURCES_TO_INJECT) {
+if (process.env.SASS_RESOURCES_TO_INJECT) {
   extraSassLoaders.push({
     loader: require.resolve('sass-resources-loader'),
     options: {
-      resources: process.env.PATHS_TO_SASS_RESOURCES_TO_INJECT
+      resources: process.env.SASS_RESOURCES_TO_INJECT
         .split(' ')
         .map(sassPath => path.resolve(paths.appPath, sassPath)),
     },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -85,11 +85,11 @@ if (process.env.ANALYZER) {
 }
 
 let extraSassLoaders = [];
-if (process.env.PATHS_TO_SASS_RESOURCES_TO_INJECT) {
+if (process.env.SASS_RESOURCES_TO_INJECT) {
   extraSassLoaders.push({
     loader: require.resolve('sass-resources-loader'),
     options: {
-      resources: process.env.PATHS_TO_SASS_RESOURCES_TO_INJECT
+      resources: process.env.SASS_RESOURCES_TO_INJECT
         .split(' ')
         .map(sassPath => path.resolve(paths.appPath, sassPath)),
     },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -83,6 +83,19 @@ if (
 if (process.env.ANALYZER) {
   doPlugins.push(new BundleAnalyzerPlugin({ defaultSizes: 'gzip' }));
 }
+
+let extraSassLoaders = [];
+if (process.env.PATHS_TO_SASS_RESOURCES_TO_INJECT) {
+  extraSassLoaders.push({
+    loader: require.resolve('sass-resources-loader'),
+    options: {
+      resources: process.env.PATHS_TO_SASS_RESOURCES_TO_INJECT
+        .split(' ')
+        .map(sassPath => path.resolve(paths.appPath, sassPath)),
+    },
+  });
+}
+
 // end adding do custom webpack plugins
 
 // This is the production configuration.
@@ -324,6 +337,7 @@ module.exports = {
                         includePaths: [].concat(paths.appSrc),
                       },
                     },
+                    ...extraSassLoaders,
                   ],
                 },
                 extractTextPluginOptions

--- a/packages/react-scripts/package-lock.json
+++ b/packages/react-scripts/package-lock.json
@@ -1,6 +1,8 @@
 {
-	"requires": true,
+	"name": "@digital-origin/react-scripts",
+	"version": "3.2.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"abab": {
 			"version": "1.0.4",
@@ -7949,6 +7951,7 @@
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
 			"integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -7985,6 +7988,7 @@
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
 			"integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+			"dev": true,
 			"requires": {
 				"fbjs": "0.8.16",
 				"loose-envify": "1.3.1",
@@ -8505,6 +8509,17 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
+			}
+		},
+		"sass-resources-loader": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/sass-resources-loader/-/sass-resources-loader-1.3.2.tgz",
+			"integrity": "sha512-7U55FKFMD7I//l/Ijm3GrqjOBw66D6NbGrwiD/uZ/S85fOB/4a3kibsaRWYkbO9t1aQPZz1V/69C5k2B1nS1bw==",
+			"requires": {
+				"async": "2.6.0",
+				"chalk": "1.1.3",
+				"glob": "7.1.2",
+				"loader-utils": "1.1.0"
 			}
 		},
 		"sax": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -58,6 +58,7 @@
     "react-dev-utils": "^4.2.1",
     "rollbar-sourcemap-webpack-plugin": "^2.2.0",
     "sass-loader": "^6.0.6",
+    "sass-resources-loader": "^1.3.2",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.6.2",


### PR DESCRIPTION
#### :tophat: What? Why?

In a new upcoming feature for our company the necessity of changing the skin of our projects at build time has arised.

In our current implementation of scss for our styles we extend from a base sass styling modifying it on each project to achieve different styling. As sass style extension is done at build time we cannot switch between styles at runtime, therefore generating a need o be able to change that sass style extension at time of build.

There are two problems the first one we need to change the sass style extension at build time and the other wee need to provide that at every sass file in our project.
As there is no dynamic imports at sass (by design) to achieve this we need to use an env variable to load one sass extension and use a sass alias.

This solution would work but that makes it quite convoluted. We can solve this problem easily by using ```sass-resource-loader``` that does what we want  ->

> This loader will @import your SASS resources into every required SASS module. So you can use your shared variables & mixins across all SASS styles without manually importing them in each file. Made to work with CSS Modules!

Taking everything explained into account we are adding the ```sass-resource-loader``` into create-react-app. You'll be able to provide a path/pattern (as specified in [here](https://github.com/shakacode/sass-resources-loader#glob-pattern-matching)) to sass resources to inject in every sass file trough a env environment called  ```SASS_RESOURCES_TO_INJECT```.

#### :ghost: GIF
![](https://media.giphy.com/media/YpQWy3hKqCxJC/giphy.gif)
