### PR TITLE
fix: enforce conditional loader to load first

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -136,6 +136,7 @@ module.exports = {
       // First Comment unneeded marked code with Conditional Loader
       {
         test: /\.(js|jsx|mjs)$/,
+        enforce: 'pre',
         include: [paths.appSrc, paths.doComponentModulesRegex],
         loader: require.resolve('webpack-conditional-loader'),
       },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -176,6 +176,7 @@ module.exports = {
       // First Comment unneeded marked code with Conditional Loader
       {
         test: /\.(js|jsx|mjs)$/,
+        enforce: 'pre',
         include: [paths.appSrc, paths.doComponentModulesRegex],
         loader: require.resolve('webpack-conditional-loader'),
       },


### PR DESCRIPTION
We were not enforcing to load conditional-loader the first one, the loader failed to remove some pieces of code when needed.

Large explanation
------------------

webpack-conditional-loader has to be loaded the first one, because it needs to read the code exactly as it was written so that it can remove some chunks of code wrapped by // #if conditionals.

Webpack rules has an attribute called ENFORCE, which you can enforce the load order of the rules to be either POST or PRE (put on the very first or very last queue of rules to be processed)

So in the last PR I put the conditional-loader the first one on the array rules, but I didn't realise that it were some other rules with ENFORCE: 'pre', overriding my order. (ESLINT rule)

So I needed to enforce 'pre' to the conditional loader plugin to finally become the very first loader in the rules array.

Hope its clear enough :)

![](https://media.giphy.com/media/Cy6PX2IRtzbjy/giphy.gif)