### PR TITLE
Add support for CSS-Modules + Merge from upstream up to v1.1.4 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 1.1.2 (April 3, 2018)
+
+#### :bug: Bug Fix
+
+* `react-scripts`
+
+  * [#4085](https://github.com/facebook/create-react-app/pull/4085) Resolve `.js` before `.mjs` files to unbreak dependencies with native ESM support. ([@leebyron](https://github.com/leebyron))
+
+#### :memo: Documentation
+
+* `react-scripts`
+
+  * [#4197](https://github.com/facebook/create-react-app/pull/4197) Add troubleshooting for Github Pages. ([@xnt](https://github.com/xnt))
+
+#### Committers: 2
+- Lee Byron ([leebyron](https://github.com/leebyron))
+- Vicente Plata ([xnt](https://github.com/xnt))
+
+### Migrating from 1.1.1 to 1.1.2
+
+Inside any created project that has not been ejected, run:
+
+```
+npm install --save --save-exact react-scripts@1.1.2
+```
+
+or
+
+```
+yarn add --exact react-scripts@1.1.2
+```
+
 ## 1.1.1 (February 2, 2018)
 
 #### :bug: Bug Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 1.1.4 (April 3, 2018)
+
+#### :bug: Bug Fix
+
+* `react-dev-utils`
+
+  * [#4250](https://github.com/facebook/create-react-app/pull/4250) Upgrade `detect-port-alt` to fix [#4189](https://github.com/facebook/create-react-app/issues/4189). ([@Timer](https://github.com/Timer))
+
+#### Committers: 1
+- Joe Haddad ([Timer](https://github.com/Timer))
+
+### Migrating from 1.1.3 to 1.1.4
+
+Inside any created project that has not been ejected, run:
+
+```
+npm install --save --save-exact react-scripts@1.1.4
+```
+
+or
+
+```
+yarn add --exact react-scripts@1.1.4
+```
+
 ## 1.1.3 (April 3, 2018)
 
 #### :bug: Bug Fix
@@ -106,7 +131,7 @@ yarn add --exact react-scripts@1.1.1
 * `react-error-overlay`
 
   * [#3474](https://github.com/facebookincubator/create-react-app/pull/3474) Allow the error overlay to be unregistered. ([@Timer](https://github.com/Timer))
-  
+
 * `create-react-app`
 
   * [#3408](https://github.com/facebookincubator/create-react-app/pull/3408) Add `--info` flag to help gather bug reports. ([@tabrindle](https://github.com/tabrindle))
@@ -132,7 +157,7 @@ yarn add --exact react-scripts@1.1.1
 * `create-react-app`
 
   * [#3320](https://github.com/facebookincubator/create-react-app/pull/3320) Fix offline installation to respect proxy from `.npmrc`. ([@mdogadailo](https://github.com/mdogadailo))
-  
+
 * `react-scripts`
 
   * [#3537](https://github.com/facebookincubator/create-react-app/pull/3537) Add `mjs` and `jsx` filename extensions to `file-loader` exclude pattern. ([@iansu](https://github.com/iansu))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 1.1.3 (April 3, 2018)
+
+#### :bug: Bug Fix
+
+* `react-scripts`
+
+  * [#4247](https://github.com/facebook/create-react-app/pull/4247) Fix `environment.dispose is not a function` error caused by a Jest bug. ([@gaearon](https://github.com/gaearon))
+
+#### Committers: 1
+- Dan Abramov ([gaearon](https://github.com/gaearon))
+
+### Migrating from 1.1.2 to 1.1.3
+
+Inside any created project that has not been ejected, run:
+
+```
+npm install --save --save-exact react-scripts@1.1.3
+```
+
+or
+
+```
+yarn add --exact react-scripts@1.1.3
+```
+
 ## 1.1.2 (April 3, 2018)
 
 #### :bug: Bug Fix

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -40,7 +40,7 @@
     "babel-code-frame": "6.26.0",
     "chalk": "1.1.3",
     "cross-spawn": "5.1.0",
-    "detect-port-alt": "1.1.5",
+    "detect-port-alt": "1.1.6",
     "escape-string-regexp": "1.0.5",
     "filesize": "3.5.11",
     "global-modules": "1.0.0",

--- a/packages/react-dev-utils/package.json
+++ b/packages/react-dev-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dev-utils",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Webpack utilities used by Create React App",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -35,9 +35,9 @@ if (process.env.SASS_RESOURCES_TO_INJECT) {
   extraSassLoaders.push({
     loader: require.resolve('sass-resources-loader'),
     options: {
-      resources: process.env.SASS_RESOURCES_TO_INJECT
-        .split(' ')
-        .map(sassPath => path.resolve(paths.appPath, sassPath)),
+      resources: process.env.SASS_RESOURCES_TO_INJECT.split(' ').map(sassPath =>
+        path.resolve(paths.appPath, sassPath)
+      ),
     },
   });
 }
@@ -109,9 +109,7 @@ module.exports = {
       // It usually still works on npm 3 without this but it would be
       // unfortunate to rely on, as react-scripts could be symlinked,
       // and thus babel-runtime might not be resolvable from the source.
-      'babel-runtime': path.dirname(
-        require.resolve('babel-runtime/package.json')
-      ),
+      'babel-runtime': path.dirname(require.resolve('babel-runtime/package.json')),
       // @remove-on-eject-end
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
@@ -152,11 +150,7 @@ module.exports = {
               eslintPath: require.resolve('eslint'),
               // @remove-on-eject-begin
               baseConfig: {
-                extends: [
-                  require.resolve(
-                    '@digital-origin/eslint-config-digital-origin'
-                  ),
-                ],
+                extends: [require.resolve('@digital-origin/eslint-config-digital-origin')],
               },
               ignore: false,
               useEslintrc: false,
@@ -191,9 +185,7 @@ module.exports = {
             options: {
               // @remove-on-eject-begin
               babelrc: false,
-              presets: [
-                require.resolve('@digital-origin/babel-preset-react-app'),
-              ],
+              presets: [require.resolve('@digital-origin/babel-preset-react-app')],
               // @remove-on-eject-end
               // This is a feature of `babel-loader` for webpack (not Babel itself).
               // It enables caching results in ./node_modules/.cache/babel-loader/
@@ -246,6 +238,50 @@ module.exports = {
                 loader: require.resolve('css-loader'),
                 options: {
                   importLoaders: 1,
+                },
+              },
+              {
+                loader: require.resolve('postcss-loader'),
+                options: {
+                  // Necessary for external CSS imports to work
+                  // https://github.com/facebookincubator/create-react-app/issues/2677
+                  ident: 'postcss',
+                  sourceMap: true,
+                  plugins: () => [
+                    require('postcss-flexbugs-fixes'),
+                    autoprefixer({
+                      browsers: [
+                        '>1%',
+                        'last 4 versions',
+                        'Firefox ESR',
+                        'not ie < 9', // React doesn't support IE8 anyway
+                      ],
+                      flexbox: 'no-2009',
+                    }),
+                  ],
+                },
+              },
+              {
+                loader: require.resolve('sass-loader'),
+                options: {
+                  outputStyle: 'expanded',
+                  sourceMap: true,
+                  includePaths: [].concat(paths.appSrc),
+                },
+              },
+              ...extraSassLoaders,
+            ],
+          },
+          {
+            test: /\.module\.scss$/,
+            use: [
+              require.resolve('style-loader'),
+              {
+                loader: require.resolve('css-loader'),
+                options: {
+                  importLoaders: 1,
+                  modules: true,
+                  localIdentName: '[name]_[local]__[hash:base64:5]',
                 },
               },
               {

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -231,13 +231,15 @@ module.exports = {
             ],
           },
           {
-            test: /\.scss$/,
+            test: /\.module\.scss$/,
             use: [
               require.resolve('style-loader'),
               {
                 loader: require.resolve('css-loader'),
                 options: {
                   importLoaders: 1,
+                  modules: true,
+                  localIdentName: '[name]_[local]__[hash:base64:5]',
                 },
               },
               {
@@ -273,15 +275,13 @@ module.exports = {
             ],
           },
           {
-            test: /\.module\.scss$/,
+            test: /\.scss$/,
             use: [
               require.resolve('style-loader'),
               {
                 loader: require.resolve('css-loader'),
                 options: {
                   importLoaders: 1,
-                  modules: true,
-                  localIdentName: '[name]_[local]__[hash:base64:5]',
                 },
               },
               {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -21,8 +21,7 @@ const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
 const RollbarSourceMapPlugin = require('rollbar-sourcemap-webpack-plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
-  .BundleAnalyzerPlugin;
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
 const publicPath = paths.servedPath;
@@ -67,10 +66,7 @@ const doPlugins = [
 ];
 
 // Add rollbar only if react app env is production and we have rollbar token
-if (
-  process.env.ROLLBAR_SERVER_TOKEN &&
-  env.raw.REACT_APP_ENV === 'production'
-) {
+if (process.env.ROLLBAR_SERVER_TOKEN && env.raw.REACT_APP_ENV === 'production') {
   doPlugins.push(
     new RollbarSourceMapPlugin({
       accessToken: process.env.ROLLBAR_SERVER_TOKEN,
@@ -89,9 +85,9 @@ if (process.env.SASS_RESOURCES_TO_INJECT) {
   extraSassLoaders.push({
     loader: require.resolve('sass-resources-loader'),
     options: {
-      resources: process.env.SASS_RESOURCES_TO_INJECT
-        .split(' ')
-        .map(sassPath => path.resolve(paths.appPath, sassPath)),
+      resources: process.env.SASS_RESOURCES_TO_INJECT.split(' ').map(sassPath =>
+        path.resolve(paths.appPath, sassPath)
+      ),
     },
   });
 }
@@ -124,9 +120,7 @@ module.exports = {
     publicPath: publicPath,
     // Point sourcemap entries to original disk location (format as URL on Windows)
     devtoolModuleFilenameTemplate: info =>
-      path
-        .relative(paths.appSrc, info.absoluteResourcePath)
-        .replace(/\\/g, '/'),
+      path.relative(paths.appSrc, info.absoluteResourcePath).replace(/\\/g, '/'),
   },
   resolve: {
     // This allows you to set a fallback for where Webpack should look for modules.
@@ -150,9 +144,7 @@ module.exports = {
       // It usually still works on npm 3 without this but it would be
       // unfortunate to rely on, as react-scripts could be symlinked,
       // and thus babel-runtime might not be resolvable from the source.
-      'babel-runtime': path.dirname(
-        require.resolve('babel-runtime/package.json')
-      ),
+      'babel-runtime': path.dirname(require.resolve('babel-runtime/package.json')),
       // @remove-on-eject-end
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
@@ -194,11 +186,7 @@ module.exports = {
               // TODO: consider separate config for production,
               // e.g. to enable no-console and no-debugger only in production.
               baseConfig: {
-                extends: [
-                  require.resolve(
-                    '@digital-origin/eslint-config-digital-origin'
-                  ),
-                ],
+                extends: [require.resolve('@digital-origin/eslint-config-digital-origin')],
               },
               ignore: false,
               useEslintrc: false,
@@ -232,9 +220,7 @@ module.exports = {
             options: {
               // @remove-on-eject-begin
               babelrc: false,
-              presets: [
-                require.resolve('@digital-origin/babel-preset-react-app'),
-              ],
+              presets: [require.resolve('@digital-origin/babel-preset-react-app')],
               // @remove-on-eject-end
               compact: true,
             },
@@ -310,6 +296,59 @@ module.exports = {
                       loader: require.resolve('css-loader'),
                       options: {
                         importLoaders: 1,
+                        minimize: true,
+                        sourceMap: true,
+                      },
+                    },
+                    {
+                      loader: require.resolve('postcss-loader'),
+                      options: {
+                        // Necessary for external CSS imports to work
+                        // https://github.com/facebookincubator/create-react-app/issues/2677
+                        ident: 'postcss',
+                        sourceMap: true,
+                        plugins: () => [
+                          require('postcss-flexbugs-fixes'),
+                          autoprefixer({
+                            browsers: [
+                              '>1%',
+                              'last 4 versions',
+                              'Firefox ESR',
+                              'not ie < 9', // React doesn't support IE8 anyway
+                            ],
+                            flexbox: 'no-2009',
+                          }),
+                        ],
+                      },
+                    },
+                    {
+                      loader: require.resolve('sass-loader'),
+                      options: {
+                        outputStyle: 'expanded',
+                        sourceMap: true,
+                        includePaths: [].concat(paths.appSrc),
+                      },
+                    },
+                    ...extraSassLoaders,
+                  ],
+                },
+                extractTextPluginOptions
+              )
+            ),
+            // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
+          },
+          {
+            test: /\.modules\.scss$/,
+            loader: ExtractTextPlugin.extract(
+              Object.assign(
+                {
+                  fallback: require.resolve('style-loader'),
+                  use: [
+                    {
+                      loader: require.resolve('css-loader'),
+                      options: {
+                        importLoaders: 1,
+                        modules: true,
                         minimize: true,
                         sourceMap: true,
                       },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -286,7 +286,7 @@ module.exports = {
             // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
           },
           {
-            test: /\.scss$/,
+            test: /\.modules\.scss$/,
             loader: ExtractTextPlugin.extract(
               Object.assign(
                 {
@@ -296,6 +296,7 @@ module.exports = {
                       loader: require.resolve('css-loader'),
                       options: {
                         importLoaders: 1,
+                        modules: true,
                         minimize: true,
                         sourceMap: true,
                       },
@@ -338,7 +339,7 @@ module.exports = {
             // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
           },
           {
-            test: /\.modules\.scss$/,
+            test: /\.scss$/,
             loader: ExtractTextPlugin.extract(
               Object.assign(
                 {
@@ -348,7 +349,6 @@ module.exports = {
                       loader: require.resolve('css-loader'),
                       options: {
                         importLoaders: 1,
-                        modules: true,
                         minimize: true,
                         sourceMap: true,
                       },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",
@@ -50,7 +50,7 @@
     "postcss-loader": "2.0.8",
     "promise": "8.0.1",
     "raf": "3.4.0",
-    "react-dev-utils": "^5.0.0",
+    "react-dev-utils": "^5.0.1",
     "resolve": "1.6.0",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -51,6 +51,7 @@
     "promise": "8.0.1",
     "raf": "3.4.0",
     "react-dev-utils": "^5.0.0",
+    "resolve": "1.6.0",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.6.2",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-origin/react-scripts",
-  "version": "3.6.0-0",
+  "version": "3.5.1-0",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",
@@ -10,13 +10,7 @@
   "bugs": {
     "url": "https://github.com/facebookincubator/create-react-app/issues"
   },
-  "files": [
-    "bin",
-    "config",
-    "scripts",
-    "template",
-    "utils"
-  ],
+  "files": ["bin", "config", "scripts", "template", "utils"],
   "bin": {
     "react-scripts": "./bin/react-scripts.js"
   },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-origin/react-scripts",
-  "version": "3.5.1-0",
+  "version": "3.6.0-0",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",
@@ -10,7 +10,13 @@
   "bugs": {
     "url": "https://github.com/facebookincubator/create-react-app/issues"
   },
-  "files": ["bin", "config", "scripts", "template", "utils"],
+  "files": [
+    "bin",
+    "config",
+    "scripts",
+    "template",
+    "utils"
+  ],
   "bin": {
     "react-scripts": "./bin/react-scripts.js"
   },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-origin/react-scripts",
-  "version": "3.6.0-0",
+  "version": "3.6.0-1",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-origin/react-scripts",
-  "version": "3.5.1-0",
+  "version": "3.6.0-0",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,11 +1,6 @@
 {
-<<<<<<< HEAD
   "name": "@digital-origin/react-scripts",
   "version": "3.5.0",
-=======
-  "name": "react-scripts",
-  "version": "1.1.4",
->>>>>>> dfbc71ce2ae07547a8544cce14a1a23fac99e071
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-origin/react-scripts",
-  "version": "3.5.0",
+  "version": "3.5.1-0",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-origin/react-scripts",
-  "version": "3.6.0-1",
+  "version": "3.6.0-2",
   "description": "Configuration and scripts for Create React App.",
   "repository": "facebookincubator/create-react-app",
   "license": "MIT",

--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -24,7 +24,7 @@ process.on('unhandledRejection', err => {
 require('../config/env');
 
 const jest = require('jest');
-const argv = process.argv.slice(2);
+let argv = process.argv.slice(2);
 
 // Watch unless on CI or in coverage mode
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {
@@ -46,5 +46,59 @@ argv.push(
     )
   )
 );
+
+// This is a very dirty workaround for https://github.com/facebook/jest/issues/5913.
+// We're trying to resolve the environment ourselves because Jest does it incorrectly.
+// TODO: remove this (and the `resolve` dependency) as soon as it's fixed in Jest.
+const resolve = require('resolve');
+function resolveJestDefaultEnvironment(name) {
+  const jestDir = path.dirname(
+    resolve.sync('jest', {
+      basedir: __dirname,
+    })
+  );
+  const jestCLIDir = path.dirname(
+    resolve.sync('jest-cli', {
+      basedir: jestDir,
+    })
+  );
+  const jestConfigDir = path.dirname(
+    resolve.sync('jest-config', {
+      basedir: jestCLIDir,
+    })
+  );
+  return resolve.sync(name, {
+    basedir: jestConfigDir,
+  });
+}
+let cleanArgv = [];
+let env = 'node';
+let next;
+do {
+  next = argv.shift();
+  if (next === '--env') {
+    env = argv.shift();
+  } else if (next.indexOf('--env=') === 0) {
+    env = next.substring('--env='.length);
+  } else {
+    cleanArgv.push(next);
+  }
+} while (argv.length > 0);
+argv = cleanArgv;
+let resolvedEnv;
+try {
+  resolvedEnv = resolveJestDefaultEnvironment(`jest-environment-${env}`);
+} catch (e) {
+  // ignore
+}
+if (!resolvedEnv) {
+  try {
+    resolvedEnv = resolveJestDefaultEnvironment(env);
+  } catch (e) {
+    // ignore
+  }
+}
+const testEnvironment = resolvedEnv || env;
+argv.push('--env', testEnvironment);
 // @remove-on-eject-end
 jest.run(argv);

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -45,12 +45,12 @@ module.exports = (resolve, rootDir, isEjecting) => {
     },
     moduleFileExtensions: [
       'web.js',
-      'mjs',
       'js',
       'json',
       'web.jsx',
       'jsx',
       'node',
+      'mjs',
     ],
   };
   if (rootDir) {

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -2209,6 +2209,16 @@ GitHub Pages doesn’t support routers that use the HTML5 `pushState` history AP
 * You could switch from using HTML5 history API to routing with hashes. If you use React Router, you can switch to `hashHistory` for this effect, but the URL will be longer and more verbose (for example, `http://user.github.io/todomvc/#/todos/42?_k=yknaj`). [Read more](https://reacttraining.com/react-router/web/api/Router) about different history implementations in React Router.
 * Alternatively, you can use a trick to teach GitHub Pages to handle 404 by redirecting to your `index.html` page with a special redirect parameter. You would need to add a `404.html` file with the redirection code to the `build` folder before deploying your project, and you’ll need to add code handling the redirect parameter to `index.html`. You can find a detailed explanation of this technique [in this guide](https://github.com/rafrex/spa-github-pages).
 
+#### Troubleshooting
+
+##### "/dev/tty: No such a device or address"
+
+If, when deploying, you get `/dev/tty: No such a device or address` or a similar error, try the follwing:
+
+1. Create a new [Personal Access Token](https://github.com/settings/tokens)
+2. `git remote set-url origin https://<user>:<token>@github.com/<user>/<repo>` .
+3. Try `npm run deploy again`
+
 ### [Heroku](https://www.heroku.com/)
 
 Use the [Heroku Buildpack for Create React App](https://github.com/mars/create-react-app-buildpack).<br>


### PR DESCRIPTION
We wanted to use the new pmt-madmin-fe project with our current create-react-app customised solution, so we needed CSS Module support. This PR aims add that support plus updating create-react-app to the latest version.

**Following changes introduced:**

- Merged latest changes from Facebook Repository (Now we are up to v1.1.4 of create-react-apps)
- Added support for SCSS modules by importing files with the following extension ".module.scss"

![colbertlateshow-stephen-colbert-3o6Zt1S65IMxMUimyY](https://media2.giphy.com/media/3o6Zt1S65IMxMUimyY/giphy.gif)