### PR TITLE
Add all css inside chunks into minified css files

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -21,7 +21,8 @@ const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
 const RollbarSourceMapPlugin = require('rollbar-sourcemap-webpack-plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+  .BundleAnalyzerPlugin;
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
 const publicPath = paths.servedPath;
@@ -66,7 +67,10 @@ const doPlugins = [
 ];
 
 // Add rollbar only if react app env is production and we have rollbar token
-if (process.env.ROLLBAR_SERVER_TOKEN && env.raw.REACT_APP_ENV === 'production') {
+if (
+  process.env.ROLLBAR_SERVER_TOKEN &&
+  env.raw.REACT_APP_ENV === 'production'
+) {
   doPlugins.push(
     new RollbarSourceMapPlugin({
       accessToken: process.env.ROLLBAR_SERVER_TOKEN,
@@ -85,9 +89,9 @@ if (process.env.SASS_RESOURCES_TO_INJECT) {
   extraSassLoaders.push({
     loader: require.resolve('sass-resources-loader'),
     options: {
-      resources: process.env.SASS_RESOURCES_TO_INJECT.split(' ').map(sassPath =>
-        path.resolve(paths.appPath, sassPath)
-      ),
+      resources: process.env.SASS_RESOURCES_TO_INJECT
+        .split(' ')
+        .map(sassPath => path.resolve(paths.appPath, sassPath)),
     },
   });
 }
@@ -120,7 +124,9 @@ module.exports = {
     publicPath: publicPath,
     // Point sourcemap entries to original disk location (format as URL on Windows)
     devtoolModuleFilenameTemplate: info =>
-      path.relative(paths.appSrc, info.absoluteResourcePath).replace(/\\/g, '/'),
+      path
+        .relative(paths.appSrc, info.absoluteResourcePath)
+        .replace(/\\/g, '/'),
   },
   resolve: {
     // This allows you to set a fallback for where Webpack should look for modules.
@@ -144,7 +150,9 @@ module.exports = {
       // It usually still works on npm 3 without this but it would be
       // unfortunate to rely on, as react-scripts could be symlinked,
       // and thus babel-runtime might not be resolvable from the source.
-      'babel-runtime': path.dirname(require.resolve('babel-runtime/package.json')),
+      'babel-runtime': path.dirname(
+        require.resolve('babel-runtime/package.json')
+      ),
       // @remove-on-eject-end
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
@@ -186,7 +194,11 @@ module.exports = {
               // TODO: consider separate config for production,
               // e.g. to enable no-console and no-debugger only in production.
               baseConfig: {
-                extends: [require.resolve('@digital-origin/eslint-config-digital-origin')],
+                extends: [
+                  require.resolve(
+                    '@digital-origin/eslint-config-digital-origin'
+                  ),
+                ],
               },
               ignore: false,
               useEslintrc: false,
@@ -220,7 +232,9 @@ module.exports = {
             options: {
               // @remove-on-eject-begin
               babelrc: false,
-              presets: [require.resolve('@digital-origin/babel-preset-react-app')],
+              presets: [
+                require.resolve('@digital-origin/babel-preset-react-app'),
+              ],
               // @remove-on-eject-end
               compact: true,
             },
@@ -467,6 +481,7 @@ module.exports = {
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
     new ExtractTextPlugin({
       filename: cssFilename,
+      allChunks: true,
     }),
     // Generate a manifest file which contains a mapping of all asset filenames
     // to their corresponding output file so that tools can pick it up without


### PR DESCRIPTION
#### :tophat: What? Why?

Customers use Hotjar, an application that allows monitoring user interaction with cbo. 

The build wasn't being generated correctly to use this application because in minified css file there were only styles from do-css-framework. Because of this, the videos generated by Hotjar, didn't apply styles and it was difficult to see the real application.
The styles defined into cbo application are in chunk files. The parameter is to include application styles in the minified file with the do-css-framework styles.

**Only line 484. The other changes are by ESLint***


#### :ghost: GIF
![](https://media.giphy.com/media/7CSUvJr3LJOo0/giphy.gif)
